### PR TITLE
Backwards compatible optimization for large options.

### DIFF
--- a/src/Models/OptionFieldGroup.php
+++ b/src/Models/OptionFieldGroup.php
@@ -53,7 +53,7 @@ class OptionFieldGroup extends BaseFieldGroup
         // load all plain values from the database, which match the prefix
         $this->plain = Option::where('option_name', 'like', $this->prefix . $filter . '_%')
             ->orWhere('option_name', 'like', '_' . $this->prefix . $filter . '_%')
-            ->when($filter, function ($query) use ($filter){
+            ->when($filter, function ($query) use ($filter) {
                 $query->orWhere('option_name', '_' . $this->prefix . $filter);
                 $query->orWhere('option_name', $this->prefix . $filter);
             })
@@ -90,7 +90,8 @@ class OptionFieldGroup extends BaseFieldGroup
     /**
      * Force model to get latest data from the DB again
      */
-    public function invalidateCache(){
+    public function invalidateCache()
+    {
         $this->loaded = false;
     }
 

--- a/src/Models/OptionFieldGroup.php
+++ b/src/Models/OptionFieldGroup.php
@@ -88,6 +88,13 @@ class OptionFieldGroup extends BaseFieldGroup
     }
 
     /**
+     * Force model to get latest data from the DB again
+     */
+    public function invalidateCache(){
+        $this->loaded = false;
+    }
+
+    /**
      * Return an option (e.g. the according BaseField)
      */
     public function getOptionField($key)

--- a/src/Models/OptionFieldGroup.php
+++ b/src/Models/OptionFieldGroup.php
@@ -43,15 +43,20 @@ class OptionFieldGroup extends BaseFieldGroup
      * Load the option data from the database & instantiate all needed BaseField
      * instances. Optionally set the prefix beforehand
      */
-    public function loadOptions(string $prefix = null)
+    public function loadOptions(string $prefix = null, ?string $filter = "")
     {
         if ($prefix) {
             $this->setPrefix($prefix);
         }
 
+        $filter = $filter ? "_" . $filter : "";
         // load all plain values from the database, which match the prefix
-        $this->plain = Option::where('option_name', 'like', $this->prefix . '_%')
-            ->orWhere('option_name', 'like', '_' . $this->prefix . '_%')
+        $this->plain = Option::where('option_name', 'like', $this->prefix . $filter . '_%')
+            ->orWhere('option_name', 'like', '_' . $this->prefix . $filter . '_%')
+            ->when($filter, function ($query) use ($filter){
+                $query->orWhere('option_name', '_' . $this->prefix . $filter);
+                $query->orWhere('option_name', $this->prefix . $filter);
+            })
 
             // key them by option_name
             ->pluck('option_value', 'option_name')


### PR DESCRIPTION
Before this PR, you couldn't grab just one specific field, sometimes you have large option pages and you only want one field for instance : 

```php
OptionFieldGroup::byTitle('Manual Rates')->first()->loadOptions("options")->getOption("exchange")->toArray(),
```
Would get all the options of Manual Rates from the DB, but : 

```php
OptionFieldGroup::byTitle('Manual Rates')->first()->loadOptions("options", "exchange")->getOption("exchange")->toArray(),
```

Only looks for `options_exchange_*` that means all the other fields, won't be selected and retrieved, this arises one question in mind, what happens in caching? well I added a function to invalidate caches : 

```php
OptionFieldGroup::byTitle('Manual Rates')->first()->invalidateCache();
``` 

There is no breaking changes just a few things added that's all!